### PR TITLE
Corrige a ordenação dos dias do evento

### DIFF
--- a/src/add_event.py
+++ b/src/add_event.py
@@ -90,7 +90,7 @@ def get_event_from_env():
         "mes": os.getenv("event_month", "").strip().lower(),
         "evento": {
             "nome": os.getenv("event_name", "").strip(),
-            "data": os.getenv("event_day", "").strip().replace(" ", "").split(","),
+            "data": sorted(os.getenv("event_day", "").strip().replace(" ", "").split(",")),
             "url": os.getenv("event_url", "").strip(),
             "cidade": os.getenv("event_city", "").strip().title(),
             "uf": os.getenv("event_state", "").strip(),


### PR DESCRIPTION
## Mudanças do PR
- Ordenação do vetor de dias ao ser extraído da variável de ambiente do github actions

## Testes:
Evento criado idêntico ao citado em #722

Evento original com erro: 
https://github.com/agenda-tech-brasil/agenda-tech-brasil/pull/700/files
![image](https://github.com/user-attachments/assets/1ab679bf-7807-41d8-8a18-7e4a2bfabcdf)

Evento criado no meu fork com a correção
https://github.com/LuccaAug/agenda-tech-brasil/pull/33/files
![image](https://github.com/user-attachments/assets/17cbb0f5-8d3f-4037-82b7-8d616369b8ba)
