### PR TITLE
Muda o nome de issues apenas criadas de um template

### DIFF
--- a/.github/ISSUE_TEMPLATE/01 - create-in-person-meeting.yml
+++ b/.github/ISSUE_TEMPLATE/01 - create-in-person-meeting.yml
@@ -1,7 +1,7 @@
 name: "💙 Criar Evento/Agenda - Presencial"
 description: Utilize essa opção para adicionar um novo evento/agenda presencial!
 title: "(Atenção: O Título da Issue é gerado automaticamente. Sendo assim, não precisa definir um título manualmente aqui.)"
-labels: ["cadastrar", "presencial"]
+labels: ["cadastrar", "presencial", "template"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/02 - create-hybrid-meeting.yml
+++ b/.github/ISSUE_TEMPLATE/02 - create-hybrid-meeting.yml
@@ -1,7 +1,7 @@
 name: "🧡 Criar Evento/Agenda - Híbrido"
 description: Utilize essa opção para adicionar um novo evento/agenda híbrido!
 title: "(Atenção: O Título da Issue é gerado automaticamente. Sendo assim, não precisa definir um título manualmente aqui.)"
-labels: ["cadastrar", "híbrido"]
+labels: ["cadastrar", "híbrido", "template"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/03 - create-online-meeting.yml
+++ b/.github/ISSUE_TEMPLATE/03 - create-online-meeting.yml
@@ -1,7 +1,7 @@
 name: "💜 Criar Evento/Agenda - Online"
 description: Utilize essa opção para adicionar um novo evento/agenda online!
 title: "(Atenção: O Título da Issue é gerado automaticamente. Sendo assim, não precisa definir um título manualmente aqui.)"
-labels: ["cadastrar", "online"]
+labels: ["cadastrar", "online", "template"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/04 - delete-meeting.yml
+++ b/.github/ISSUE_TEMPLATE/04 - delete-meeting.yml
@@ -1,7 +1,7 @@
 name: "💔 Cancelar Evento/Agenda"
 description: Utilize essa opção para remover um evento/agenda que foi cancelado!
 title: "(Atenção: O Título da Issue é gerado automaticamente. Sendo assim, não precisa definir um título manualmente aqui.)"
-labels: ["cancelar"]
+labels: ["cancelar", "template"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/05 - archive-event.yml
+++ b/.github/ISSUE_TEMPLATE/05 - archive-event.yml
@@ -1,7 +1,7 @@
 name: "📦 Arquivar Mês/Ano"
 description: Utilize essa opção para arquivar mês do evento
 title: "(Atenção: O Título da Issue é gerado automaticamente. Sendo assim, não precisa definir um título manualmente aqui.)"
-labels: ["arquivar"]
+labels: ["arquivar", "template"]
 body:
   - type: dropdown
     id: event_year

--- a/.github/workflows/change_issue_title.yml
+++ b/.github/workflows/change_issue_title.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   change-issue-name:
+    if: contains(github.event.issue.labels.*.name, 'template')
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/change_issue_title.yml
+++ b/.github/workflows/change_issue_title.yml
@@ -18,7 +18,8 @@ jobs:
           # Extraindo o nome do evento do corpo da issue
           event_info="${{ github.event.issue.body }}"
 
-          LABELS="${{ toJson(github.event.issue.labels) }}"
+          # Get only the label names and join them
+          LABELS="${{ join(github.event.issue.labels.*.name, ',') }}"
 
           get_event_value() {
             local event_info="$1"
@@ -29,7 +30,7 @@ jobs:
           event_name=$(get_event_value "$event_info" 'Nome do(a) Evento/Agenda')
 
           if [ -z "$event_name" ]; then
-            if ! echo "$LABELS" | grep -q 'name: arquivar'; then
+            if ! echo "$LABELS" | grep -q 'arquivar'; then
               echo "Nome do evento não encontrado no corpo da issue."
               exit 1
             fi 
@@ -37,7 +38,7 @@ jobs:
           
           new_title="Agenda/Evento: $event_name"
 
-          if echo "$LABELS" | grep -q 'name: arquivar'; then
+          if echo "$LABELS" | grep -q 'arquivar'; then
               archive_month=$(get_event_value "$event_info" 'Mês para ser Arquivado')
               archive_year=$(get_event_value "$event_info" 'Ano do Mês a ser Arquivado ou Ano a ser arquivado')
 


### PR DESCRIPTION
## Mudanças necessárias por um colaborador
Como dito em #422, a estratégia de correção utilizada aqui depende da criação de uma label chamada template de algum dos colaboradores que tenham tal permissão.

## Mudanças do PR
- Adicionados aos 5 templates a label `template`
- Adicionado checker ao rodar github action que muda o título
- Corrigido problema na github action que muda o título 
  - Anteriormente funcionava pois nenhuma das labels usadas possuiam uma descrição.
  - Código modificado para que pegue apenas o nome das labels, já que é a única informação utilizada e a descrição gerava bug.

## Testes:
### Evento criado a partir de um template
Funcionamento normal tal qual era antes

Issue: https://github.com/LuccaAug/agenda-tech-brasil/issues/30
![image](https://github.com/user-attachments/assets/f3ae48ea-7570-42ab-9734-c5acfc87463b)

Github Action: https://github.com/LuccaAug/agenda-tech-brasil/actions/runs/14360474929
![image](https://github.com/user-attachments/assets/6a1214e5-f3ab-413c-bb37-5fa364da8e14)

### Evento criado sem template
Github action nem é iniciada

Issue: https://github.com/LuccaAug/agenda-tech-brasil/issues/29
![image](https://github.com/user-attachments/assets/17be621b-dac5-42f8-b83e-fdc0f75c3e63)

Github Action: https://github.com/LuccaAug/agenda-tech-brasil/actions/runs/14360321689
![image](https://github.com/user-attachments/assets/2b2b7bd5-14e1-4504-b871-542e89f145f3)

### Evento criado antes da correção dos labels:
Json criado era interpretado como comando
```
LABELS="${{ toJson(github.event.issue.labels) }}"
```

Github Action: https://github.com/LuccaAug/agenda-tech-brasil/actions/runs/14359734468
![image](https://github.com/user-attachments/assets/dd24a7d0-cb90-4a83-bd84-047d7af25485)

Linha 52 que está gerando o erro:
![image](https://github.com/user-attachments/assets/e2c77e47-5051-4fcf-8223-ade1bc982b03)

