### PR TITLE
Hotfix: Desabilitar Temporariamente Geração de MD após Merge

### DIFF
--- a/.github/workflows/generate-markdown.yml
+++ b/.github/workflows/generate-markdown.yml
@@ -1,14 +1,18 @@
 name: Gerar Markdown após Push
 on:
-  push:
-    branches: ["main"]
-
+  #  push:
+  #  branches: ["main"]
+  workflow_run:
+    workflows: ["Criar PR para Cadastrar Agenda/Evento"]
+    types:
+      - completed
 permissions:
   contents: write
 
 jobs:
   generate-markdown:
-    if: github.ref == 'refs/heads/main'
+    #if: github.ref == 'refs/heads/main'
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checar o repositório


### PR DESCRIPTION
- O objetivo desse PR é subir uma modificação temporária para mudar como a forma de geração de Markdown é feita, enquanto não criamos um Application para fazer essa geração de forma correta.
