### PR TITLE
Potential fix for code scanning alert no. 8: Code injection

### DIFF
--- a/.github/workflows/create-event.yml
+++ b/.github/workflows/create-event.yml
@@ -211,9 +211,11 @@ jobs:
 
       - name: Obter detalhes do evento da issue
         id: event_details
+        env:
+          EVENT_INFO: ${{ github.event.issue.body }}
         run: |
 
-          event_info="${{ github.event.issue.body }}"
+          event_info="$EVENT_INFO"
 
           get_event_values() {
             local event_info="$1"


### PR DESCRIPTION
Potential fix for [https://github.com/agenda-tech-brasil/agenda-tech-brasil/security/code-scanning/8](https://github.com/agenda-tech-brasil/agenda-tech-brasil/security/code-scanning/8)

To fix the code injection vulnerability, we should avoid using `${{ github.event.issue.body }}` directly in the shell script. Instead, set it as an environment variable in the workflow step, and then reference it using shell-native syntax (`$EVENT_INFO`) inside the script. This prevents shell injection because the shell will treat the value as data, not as code. Specifically, in the step "Obter detalhes do evento da issue", add an `env:` block to set `EVENT_INFO: ${{ github.event.issue.body }}` and replace the assignment `event_info="${{ github.event.issue.body }}"` with `event_info="$EVENT_INFO"`. No other changes are needed, as the rest of the script uses the variable as intended.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
