### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,6 +1,8 @@
 # This is a basic workflow to help you get started with Actions
 
 name: CI
+permissions:
+  contents: read
 
 # Controls when the workflow will run
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/agenda-tech-brasil/agenda-tech-brasil/security/code-scanning/1](https://github.com/agenda-tech-brasil/agenda-tech-brasil/security/code-scanning/1)

To fix the problem, we should add a `permissions` block to the workflow file `.github/workflows/markdown-lint.yml`. The block should be placed at the top level (before `jobs:`) to apply to all jobs, unless a job needs more specific permissions. For this workflow, the jobs only need to read repository contents (to check out code and lint files), so the minimal required permission is `contents: read`. No write permissions are needed. The block should be added after the `name:` and before `on:` for clarity and convention.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
