### PR TITLE
Potential fix for code scanning alert no. 7: Code injection

### DIFF
--- a/.github/workflows/create-event.yml
+++ b/.github/workflows/create-event.yml
@@ -116,9 +116,9 @@ jobs:
 
       - name: Obter detalhes do evento da issue
         id: event_details
+        env:
+          EVENT_INFO: ${{ github.event.issue.body }}
         run: |
-
-          event_info="${{ github.event.issue.body }}"
 
           get_event_values() {
             local event_info="$1"
@@ -136,13 +136,13 @@ jobs:
             echo "$1" | awk '{ for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2); }1'
           }
 
-          event_name=$(get_event_values "$event_info" 'Nome do(a) Evento/Agenda')
-          event_url=$(get_event_values "$event_info" 'Site do(a) Evento/Agenda')
-          event_city=$(get_event_values "$event_info" 'Cidade do(a) Evento/Agenda')
-          event_state=$(get_event_values "$event_info" 'Estado Federativo do(a) Evento/Agenda')
-          event_year=$(get_event_values "$event_info" 'Ano do(a) Evento/Agenda')
-          event_month=$(get_event_values "$event_info" 'Mês do(a) Evento/Agenda')
-          event_day=$(get_event_values "$event_info" 'Dia do(a) Evento/Agenda')
+          event_name=$(get_event_values "$EVENT_INFO" 'Nome do(a) Evento/Agenda')
+          event_url=$(get_event_values "$EVENT_INFO" 'Site do(a) Evento/Agenda')
+          event_city=$(get_event_values "$EVENT_INFO" 'Cidade do(a) Evento/Agenda')
+          event_state=$(get_event_values "$EVENT_INFO" 'Estado Federativo do(a) Evento/Agenda')
+          event_year=$(get_event_values "$EVENT_INFO" 'Ano do(a) Evento/Agenda')
+          event_month=$(get_event_values "$EVENT_INFO" 'Mês do(a) Evento/Agenda')
+          event_day=$(get_event_values "$EVENT_INFO" 'Dia do(a) Evento/Agenda')
 
           if [[ $event_day == "_No response_" ]]; then
             event_month=TBA


### PR DESCRIPTION
Potential fix for [https://github.com/agenda-tech-brasil/agenda-tech-brasil/security/code-scanning/7](https://github.com/agenda-tech-brasil/agenda-tech-brasil/security/code-scanning/7)

To fix the code injection vulnerability, we should avoid directly interpolating `${{ github.event.issue.body }}` into the shell script. Instead, we should pass it as an environment variable using the `env:` key in the step, and then reference it in the shell script using `$EVENT_INFO`. This approach ensures that the value is treated as data, not as code, and prevents shell injection. Specifically, in the step with `id: event_details`, move the assignment of `event_info` to the `env:` section, and update the script to use `$EVENT_INFO` instead of `event_info="${{ github.event.issue.body }}"`. All subsequent references to `event_info` in the script should be updated to use `$EVENT_INFO`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
