### PR TITLE
Potential fix for code scanning alert no. 11: Environment variable built from user-controlled sources

### DIFF
--- a/.github/workflows/create-event.yml
+++ b/.github/workflows/create-event.yml
@@ -156,13 +156,13 @@ jobs:
           event_state=$(extract_abbreviation "${event_state}")
 
 
-          echo "event_name=$(echo "${event_name}" | tr -d '\n\r')" >> $GITHUB_ENV
-          echo "event_url=$(echo "${event_url}" | tr -d '\n\r')" >> $GITHUB_ENV
-          echo "event_city=$(echo "${event_city}" | tr -d '\n\r')" >> $GITHUB_ENV
-          echo "event_state=$(echo "${event_state}" | tr -d '\n\r')" >> $GITHUB_ENV
-          echo "event_year=$(echo "${event_year}" | tr -d '\n\r')" >> $GITHUB_ENV
-          echo "event_month=$(echo "${event_month}" | tr -d '\n\r')" >> $GITHUB_ENV
-          echo "event_day=$(echo "${event_day}" | tr -d '\n\r')" >> $GITHUB_ENV
+          echo "event_name=$(sanitize_env_value "${event_name}")" >> $GITHUB_ENV
+          echo "event_url=$(sanitize_env_value "${event_url}")" >> $GITHUB_ENV
+          echo "event_city=$(sanitize_env_value "${event_city}")" >> $GITHUB_ENV
+          echo "event_state=$(sanitize_env_value "${event_state}")" >> $GITHUB_ENV
+          echo "event_year=$(sanitize_env_value "${event_year}")" >> $GITHUB_ENV
+          echo "event_month=$(sanitize_env_value "${event_month}")" >> $GITHUB_ENV
+          echo "event_day=$(sanitize_env_value "${event_day}")" >> $GITHUB_ENV
 
       - name: Definir tipo de Evento como Híbrido
         run: |

--- a/.github/workflows/create-event.yml
+++ b/.github/workflows/create-event.yml
@@ -156,13 +156,13 @@ jobs:
           event_state=$(extract_abbreviation "${event_state}")
 
 
-          echo "event_name=${event_name}" >> $GITHUB_ENV
-          echo "event_url=${event_url}" >> $GITHUB_ENV
-          echo "event_city=${event_city}" >> $GITHUB_ENV
-          echo "event_state=${event_state}" >> $GITHUB_ENV
-          echo "event_year=${event_year}" >> $GITHUB_ENV
-          echo "event_month=${event_month}" >> $GITHUB_ENV
-          echo "event_day=${event_day}" >> $GITHUB_ENV
+          echo "event_name=$(echo "${event_name}" | tr -d '\n\r')" >> $GITHUB_ENV
+          echo "event_url=$(echo "${event_url}" | tr -d '\n\r')" >> $GITHUB_ENV
+          echo "event_city=$(echo "${event_city}" | tr -d '\n\r')" >> $GITHUB_ENV
+          echo "event_state=$(echo "${event_state}" | tr -d '\n\r')" >> $GITHUB_ENV
+          echo "event_year=$(echo "${event_year}" | tr -d '\n\r')" >> $GITHUB_ENV
+          echo "event_month=$(echo "${event_month}" | tr -d '\n\r')" >> $GITHUB_ENV
+          echo "event_day=$(echo "${event_day}" | tr -d '\n\r')" >> $GITHUB_ENV
 
       - name: Definir tipo de Evento como Híbrido
         run: |


### PR DESCRIPTION
Potential fix for [https://github.com/agenda-tech-brasil/agenda-tech-brasil/security/code-scanning/11](https://github.com/agenda-tech-brasil/agenda-tech-brasil/security/code-scanning/11)

To fix this vulnerability, all values derived from user-controlled sources (such as the issue body) must be sanitized before being written to `$GITHUB_ENV`. For single-line environment variables, the safest approach is to remove newlines and carriage returns from the value before writing it. This can be done using `tr -d '\n\r'` or similar. For multi-line variables (not present here), a unique delimiter should be used, but in this case, all variables are single-line.

Specifically, in the block where environment variables are written (lines 159–165), each value should be sanitized to remove newlines and carriage returns. This can be done by piping the value through `tr -d '\n\r'` before echoing it to `$GITHUB_ENV`.

No new methods or imports are needed, but the shell code in the workflow must be updated to sanitize each variable before writing it to the environment.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
