### PR TITLE
Potential fix for code scanning alert no. 10: Code injection

### DIFF
--- a/.github/workflows/create-event.yml
+++ b/.github/workflows/create-event.yml
@@ -194,13 +194,14 @@ jobs:
           gh pr create \
           -B main \
           -H ${{ env.branch_name }} \
-          --title "Agenda/Evento: ${{ env.event_name }}" \
+          --title "Agenda/Evento: $event_name" \
           --body "Closes #${{ github.event.issue.number }}" \
           --label cadastrar \
           --label híbrido \
           --reviewer "${{ env.reviewers }}"
         env:
           GH_TOKEN: ${{ github.token }}
+          event_name: ${{ env.event_name }}
 
   create-online-event:
     if: contains(github.event.issue.labels.*.name, 'cadastrar') && contains(github.event.issue.labels.*.name, 'online')


### PR DESCRIPTION
Potential fix for [https://github.com/agenda-tech-brasil/agenda-tech-brasil/security/code-scanning/10](https://github.com/agenda-tech-brasil/agenda-tech-brasil/security/code-scanning/10)

To fix the code injection vulnerability, we should avoid using `${{ env.event_name }}` directly in the shell command. Instead, set the value of `event_name` as an environment variable in the workflow step, and reference it using native shell syntax (`$event_name`) within the shell script. This prevents the shell from interpreting injected metacharacters, as the value is passed as an environment variable rather than interpolated into the command line. Specifically, in the "Criar Pull Request" step (lines 192-202), update the `run` script to use `$event_name` and set `event_name: ${{ env.event_name }}` in the `env:` block for the step. No changes to the logic or functionality are required, only the way the value is referenced.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
