### PR TITLE
fix(create-event): corrige extração de campos no job híbrido

### DIFF
--- a/.github/workflows/create-event.yml
+++ b/.github/workflows/create-event.yml
@@ -209,7 +209,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checar o repositório
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Obter detalhes do evento da issue
         id: event_details


### PR DESCRIPTION
## Contexto

O workflow de cadastro automático via Issue estava com a extração de campos **no job de eventos híbridos** diferente do padrão usado em **online**, o que gerava inconsistência na leitura do corpo da issue.

## O que mudou

- Padroniza a leitura do corpo da issue no job **híbrido** para usar `EVENT_INFO` + `printf`, alinhando com o job **online**.
- Ajusta a extração dos campos para sempre usar a variável `event_info` (mesma abordagem do online).
- Atualiza o `actions/checkout` do job **online** para `v4`.

Arquivo impactado: [.github/workflows/create-event.yml](.github/workflows/create-event.yml)

## Por que

- Evita inconsistências ao parsear o corpo da issue (formulário em Markdown), deixando o job híbrido com a mesma “estrutura”/fluxo do job online.
- Mantém as actions atualizadas (checkout `v4`).

## Como testar

1. Abra uma issue usando o template de cadastro de evento hibrido.
2. Preencha os campos (Nome, Site, Cidade, UF, Ano, Mês e Dia).
3. Verifique a execução do workflow **[CI] Cadastrar Agenda/Evento**:
   - Passo “Obter detalhes do evento da issue” exporta as envs (`event_*`) corretamente
   - Passo “Adiciona o Evento/Agenda no database.json” executa sem erro
   - É criada a branch `feature/add-event-issue-<n>` e um PR “Agenda/Evento: <nome>” com `Closes #<issue>`

## Checklist

- [x] Job `create-hybrid-event` roda com issue `cadastrar` + `híbrido`
- [x] PR é criado automaticamente com labels esperadas
- [x] `src/db/database.json` é atualizado corretamente