### PR TITLE
Fix: Corrigir Link do arquivo de Contribuição

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ _Sabe aquele evento de tecnologia que você procura, mas não sabe onde encontra
 
 **Não encontrou o evento, palestra ou iniciativa que estava procurando?**
 
-Pode ser que ainda não tenhamos adicionado ao nosso calendário de eventos! Se você conhece algum evento que acredita ser relevante para estar aqui, convidamos você a adicioná-lo. Está interessado(a) em nos ajudar nisso? [Clique aqui para aprender como incluir novos eventos e ajudar o repositório a crescer!](https://github.com/agenda-tech-brasil/agenda-tech-brasil/blob/main/CONTRIBUTING.md)
+Pode ser que ainda não tenhamos adicionado ao nosso calendário de eventos! Se você conhece algum evento que acredita ser relevante para estar aqui, convidamos você a adicioná-lo. Está interessado(a) em nos ajudar nisso? [Clique aqui para aprender como incluir novos eventos e ajudar o repositório a crescer!](.github/CONTRIBUTING.md)
 
 ## Eventos em 2026
 <!-- ANO2026:START -->

--- a/src/templates/events.md.j2
+++ b/src/templates/events.md.j2
@@ -19,7 +19,7 @@ _Sabe aquele evento de tecnologia que você procura, mas não sabe onde encontra
 
 **Não encontrou o evento, palestra ou iniciativa que estava procurando?**
 
-Pode ser que ainda não tenhamos adicionado ao nosso calendário de eventos! Se você conhece algum evento que acredita ser relevante para estar aqui, convidamos você a adicioná-lo. Está interessado(a) em nos ajudar nisso? [Clique aqui para aprender como incluir novos eventos e ajudar o repositório a crescer!](https://github.com/agenda-tech-brasil/agenda-tech-brasil/blob/main/CONTRIBUTING.md)
+Pode ser que ainda não tenhamos adicionado ao nosso calendário de eventos! Se você conhece algum evento que acredita ser relevante para estar aqui, convidamos você a adicioná-lo. Está interessado(a) em nos ajudar nisso? [Clique aqui para aprender como incluir novos eventos e ajudar o repositório a crescer!](.github/CONTRIBUTING.md)
 
 {% for ano in data.eventos %}
 {% if not ano.arquivado %}


### PR DESCRIPTION
This pull request updates the reference link to the contributing guidelines in both the `README.md` and `src/templates/events.md.j2` files. The link now points to the local `.github/CONTRIBUTING.md` file instead of the GitHub URL, ensuring consistency and easier access for contributors.

Documentation updates:

* Changed the contributing guidelines link in `README.md` to reference `.github/CONTRIBUTING.md` locally instead of the full GitHub URL.
* Updated the contributing guidelines link in `src/templates/events.md.j2` to reference `.github/CONTRIBUTING.md` locally instead of the full GitHub URL.