### PR TITLE
Security: Fix 4 findings in GitHub Actions workflows

### DIFF
--- a/.github/workflows/archive-events.yml
+++ b/.github/workflows/archive-events.yml
@@ -21,9 +21,11 @@ jobs:
 
       - name: Obter detalhes do mês e ano da issue
         id: issue_details
+        env:
+            ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
 
-          event_info="${{ github.event.issue.body }}"
+          event_info="$ISSUE_BODY"
 
           get_event_values() {
             local event_info="$1"

--- a/.github/workflows/change_issue_title.yml
+++ b/.github/workflows/change_issue_title.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Atualizar título da issue
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
           # Extraindo o nome do evento do corpo da issue
           event_info="$ISSUE_BODY"
@@ -34,7 +34,7 @@ jobs:
             if ! echo "$LABELS" | grep -q 'arquivar'; then
               echo "Nome do evento não encontrado no corpo da issue."
               exit 1
-            fi 
+            fi
           fi
 
           new_title="Agenda/Evento: $event_name"
@@ -51,7 +51,7 @@ jobs:
               else
                 new_title="Arquivar: ${archive_month}/${archive_year}"
               fi
-          fi 
+          fi
 
           # Modificando o título da issue usando a API do GitHub
           issue_number="${{ github.event.issue.number }}"

--- a/.github/workflows/change_issue_title.yml
+++ b/.github/workflows/change_issue_title.yml
@@ -14,9 +14,10 @@ jobs:
       - name: Atualizar título da issue
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
           # Extraindo o nome do evento do corpo da issue
-          event_info="${{ github.event.issue.body }}"
+          event_info="$ISSUE_BODY"
 
           # Get only the label names and join them
           LABELS="${{ join(github.event.issue.labels.*.name, ',') }}"

--- a/.github/workflows/create-event.yml
+++ b/.github/workflows/create-event.yml
@@ -21,9 +21,11 @@ jobs:
 
       - name: Obter detalhes do evento da issue
         id: event_details
+        env:
+            ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
 
-          event_info="${{ github.event.issue.body }}"
+          event_info="$ISSUE_BODY"
 
           get_event_values() {
             local event_info="$1"

--- a/.github/workflows/delete-event.yml
+++ b/.github/workflows/delete-event.yml
@@ -21,9 +21,11 @@ jobs:
 
       - name: Obter detalhes do evento da issue
         id: event_details
+        env:
+            ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
 
-          event_info="${{ github.event.issue.body }}"
+          event_info="$ISSUE_BODY"
 
           get_event_values() {
             local event_info="$1"


### PR DESCRIPTION
## Security: 4 findings across 1 rule

### Fixed (deterministic, no AI)

**shell-injection-expr** — [What is this?](https://sentinel-bot.copilotkit.dev/rules/shell-injection-expr)
- `archive-events.yml` line 26: Attacker-controllable expression ${{ github.event.issue.body }} in run: block — shell injection risk
- `change_issue_title.yml` line 19: Attacker-controllable expression ${{ github.event.issue.body }} in run: block — shell injection risk
- `create-event.yml` line 26: Attacker-controllable expression ${{ github.event.issue.body }} in run: block — shell injection risk
- `delete-event.yml` line 26: Attacker-controllable expression ${{ github.event.issue.body }} in run: block — shell injection risk

### How this was detected

This finding was identified by deterministic pattern matching — no AI or machine learning was used in the detection. Sentinel uses static analysis rules that match known-vulnerable YAML patterns against a database of documented exploit vectors. Every finding maps to a specific, reproducible pattern. [Source code](https://github.com/jpr5/sentinel) is open for inspection.

---
<sub>&#x1f6e1;&#xfe0f; This PR was generated by [Sentinel](https://sentinel.copilotkit.dev), an open-source security scanner. [Why this PR?](https://medium.com/@jordanritter/security-hardening-github-workflows-at-scale-d291a33774e1) · Free, no tracking</sub>

[&#x2705; Add Sentinel to this repo](https://sentinel-bot.copilotkit.dev/adopt?repo=agenda-tech-brasil%2Fagenda-tech-brasil&token=2f3c7ac8-c2c8-4de1-a340-ad8e4e59de73) · [&#x1f6ab; Opt out of future PRs](https://sentinel-bot.copilotkit.dev/opt-out?repo=agenda-tech-brasil%2Fagenda-tech-brasil&token=3b2e7f5c-369e-472d-a9c2-ac4f15004108)
