### PR TITLE
Feature: Geração automática de Markdown para eventos arquivados

### DIFF
--- a/.github/workflows/archive-events.yml
+++ b/.github/workflows/archive-events.yml
@@ -56,6 +56,11 @@ jobs:
           pip3 install -r src/requirements.txt
           python3 src/archive.py
 
+      - name: Gerar markdown dos eventos arquivados
+        run: |
+          python3 src/export_archive.py
+          python3 src/generate_page.py
+
       - name: Set up Git
         run: |
           git config --global user.name "${{ github.event.issue.user.login }}"
@@ -65,8 +70,8 @@ jobs:
         run: |
           branch_name="feature/add-event-issue-${{ github.event.issue.number }}"
           git checkout -b $branch_name
-          git add src/db/database.json
-          git commit -m "Adicionando novo evento: ${{ env.event_name }}"
+          git add src/db/database.json arquivo README.md
+          git commit -m "Arquivando: ${{ env.archive_month != '' && format('{0}/{1}', env.archive_month, env.archive_year) || env.archive_year }}"
           git push origin $branch_name
 
           echo "branch_name=${branch_name}" >> $GITHUB_ENV

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ _Sabe aquele evento de tecnologia que você procura, mas não sabe onde encontra
 
 <h2 align="center">Selecione o mês do Evento</h2>
 <p class="navigation" align="center">
-<a href="#janeiro">Janeiro</a>・<a href="#fevereiro">Fevereiro</a>・<a href="#março">Março</a>・<a href="#maio">Maio</a>・<a href="#junho">Junho</a>・<a href="#julho">Julho</a>・<a href="#agosto">Agosto</a>・<a href="#setembro">Setembro</a>・<a href="#outubro">Outubro</a>・<a href="#novembro">Novembro</a>・<a href="#dezembro">Dezembro</a></p>
+<a href="#janeiro">Janeiro</a>・<a href="#fevereiro">Fevereiro</a>・<a href="#março">Março</a>・<a href="#abril">Abril</a>・<a href="#maio">Maio</a>・<a href="#junho">Junho</a>・<a href="#julho">Julho</a>・<a href="#agosto">Agosto</a>・<a href="#setembro">Setembro</a>・<a href="#outubro">Outubro</a>・<a href="#novembro">Novembro</a>・<a href="#dezembro">Dezembro</a></p>
 
 ## Contribuindo
 
@@ -47,6 +47,15 @@ Pode ser que ainda não tenhamos adicionado ao nosso calendário de eventos! Se 
 - 28: [Tosconf[6]](https://tosconf.lhc.net.br) - _Campinas/SP_ ![presencial]
 - 28: [SQL Saturday](https://sqlsaturday.com/2026-03-28-sqlsaturday1142/) - _Guarulhos/SP_ ![presencial]
 <!-- MARÇO:END -->
+### Abril
+<!-- ABRIL:START -->
+- 02: [Código Aberto - Magalu Cloud](https://discord.com/events/1327339621306073171/1487184152167186472) ![online]
+- 11: [Paraibajs](https://linktr.ee/paraibajs) - _João Pessoa/PB_ ![presencial]
+- 18: [GHC - GYN Hacker Conference](https://hubconnecteventos.com.br/evento/ghc) - _Goiânia/GO_ ![presencial]
+- 22: [Caminhos pra carreira internacional em Cloud](https://www.linkedin.com/events/7448146395175395328/) - _Montes Claros/MG_ ![presencial]
+- 25: [MiniDebconf Campinas 2026](https://campinas.mini.debconf.org/sobre/evento/) - _Campinas/SP_ ![híbrido]
+- 29: [Tech Made in Brazil #01 - Magalu Cloud](https://luma.com/g4lgjals) - _São Paulo/SP_ ![presencial]
+<!-- ABRIL:END -->
 ### Maio
 <!-- MAIO:START -->
 - 01: [Python Sul 2026](https://sul.python.org.br/) - _Londrina/PR_ ![presencial]
@@ -54,13 +63,20 @@ Pode ser que ainda não tenhamos adicionado ao nosso calendário de eventos! Se 
 - 11: [The Tech Summit](https://thetechsummit.com.br/) - _São Paulo/SP_ ![presencial]
 - 13 e 14: [AI StartSe Festival 2026](https://pages.startse.com/ai-festival-ingressos) - _São Paulo/SP_ ![presencial]
 - 13, 14 e 15: [São Paulo Innovation Week](https://saopauloinnovationweek.com.br/) - _São Paulo/SP_ ![presencial]
+- 16: [Devopsdays Natal](https://linktr.ee/devopsdaysnatal) - _Natal/RN_ ![presencial]
 - 21: [APIX - API Experience](https://www.sensedia.com.br/apix) - _São Paulo/SP_ ![presencial]
+- 26: [Meetup: Organizando o código com Package by component + C4 + Structurizr](https://organizandoocodigo.eventize.com.br/) - _Porto Alegre/RS_ ![presencial]
+- 28: [Insurtech Brasil](https://www.insurtechbrasil.com/) - _São Paulo/SP_ ![presencial]
 - 30: [DunaSec 2026](https://dunasec.com.br) - _Natal/RN_ ![presencial]
+- 30: [NOSS 2026 - Nosso Open Source Summit](https://github.com/cumbucadev/noss/tree/main/2026) ![online]
 <!-- MAIO:END -->
 ### Junho
 <!-- JUNHO:START -->
+- 01: [Agile Trends Nordeste](https://www.instagram.com/agiletrends/) - _Recife/PE_ ![presencial]
 - 01 e 02: [Agile Trends Nordeste](https://doity.com.br/agile-trends-nordeste-2026) - _Recife/PE_ ![presencial]
+- 02: [Agile Trends Nordeste](https://www.instagram.com/agiletrends/) - _Recife/PE_ ![presencial]
 - 08, 09, 10 e 11: [Web Summit Rio 2026](https://rio.websummit.com/) - _Rio De Janeiro/RJ_ ![presencial]
+- 20: [Microsoft Build //localhost:florianópolis](https://developer.microsoft.com/pt-br/reactor/events/27206/) - _Florianópolis/SC_ ![presencial]
 <!-- JUNHO:END -->
 ### Julho
 <!-- JULHO:START -->
@@ -71,15 +87,21 @@ Pode ser que ainda não tenhamos adicionado ao nosso calendário de eventos! Se 
 ### Agosto
 <!-- AGOSTO:START -->
 - 01: [Agile Trends São Paulo](https://doity.com.br/agile-trends-2026) - _São Paulo/SP_ ![presencial]
+- 01: [Mulher Tech Sim Senhor](https://www.instagram.com/mulhertechsimsr/) - _João Pessoa/PB_ ![presencial]
 - 05 e 06: [TDC Experience Rio Innovation Week | Píer Mauá](https://thedevconf.com/tdc/2026/index.html) - _Rio De Janeiro/RJ_ ![híbrido]
 - 14: [Codecon Summit 2026](https://eventos.codecon.dev/eventos/codecon-summit-26) - _Pinhais/PR_ ![presencial]
+- 14 e 15: [RogaDX](https://rogadx.com/) - _Maceió/AL_ ![presencial]
 - 26 e 27: [TDC Experience São Carlos](https://thedevconf.com/tdc/2026/index.html) - _São Carlos/SP_ ![híbrido]
+- 29: [Tech Woman](https://www.instagram.com/techwoman.rec/) - _Recife/PE_ ![presencial]
 <!-- AGOSTO:END -->
 ### Setembro
 <!-- SETEMBRO:START -->
 - 02, 03 e 04: [Gophercon LATAM 2026](https://gopherconlatam.org/) - _Florianópolis/SC_ ![presencial]
-- 23, 24 e 25: [TDC São Paulo](https://thedevconf.com/tdc/2026/index.html) - _São Paulo/SP_ ![híbrido]
+- 02, 03 e 04: [pgconf.brasil 2026](https://2026.pgconf.com.br/) - _Blumenau/SC_ ![presencial]
+- 08, 09, 10 e 11: [41° Simpósio brasileiro de banco de dados](https://sbbd.org.br/2026/) - _São Carlos/SP_ ![presencial]
+- 08, 09, 10 e 11: [CBSOFT'26 - Congresso Brasileiro de Software](https://cbsoft.sbc.org.br/2026/pt/) - _Sao Paulo/SP_ ![híbrido]
 - 20: [RecrutaTech 9ª edição](https://recrutatech.com.br/) - _Curitiba/PR_ ![presencial]
+- 23, 24 e 25: [TDC São Paulo](https://thedevconf.com/tdc/2026/index.html) - _São Paulo/SP_ ![híbrido]
 <!-- SETEMBRO:END -->
 ### Outubro
 <!-- OUTUBRO:START -->
@@ -88,9 +110,13 @@ Pode ser que ainda não tenhamos adicionado ao nosso calendário de eventos! Se 
 ### Novembro
 <!-- NOVEMBRO:START -->
 - 11 e 12: [TDC Experience Recife | Rec'n'Play](https://thedevconf.com/tdc/2026/index.html) - _Recife/PE_ ![híbrido]
+- 26: [Front in Floripa 2026](https://frontin.floripa.br) - _Florianópolis/SC_ ![presencial]
+- 28: [Front in Floripa](https://frontin.floripa.br/) - _Florianópolis/SC_ ![presencial]
+- 28 e 29: [GambiConf 2026](https://gambiconf.dev/) - _São Paulo/SP_ ![híbrido]
 <!-- NOVEMBRO:END -->
 ### Dezembro
 <!-- DEZEMBRO:START -->
+- 03, 04, 05 e 06: [PHP Conference Brasil 2026](https://phpconference.com.br/) ![online]
 - 09 e 10: [TDCX PORTO ALEGRE](https://thedevconf.com/tdc/2026/index.html) - _Porto Alegre/RS_ ![híbrido]
 <!-- DEZEMBRO:END -->
 <!-- ANO2026:END -->
@@ -107,6 +133,7 @@ Pode ser que ainda não tenhamos adicionado ao nosso calendário de eventos! Se 
 - [Eventos 2022](https://github.com/agenda-tech-brasil/agenda-tech-brasil/blob/main/arquivo/2022.md)
 - [Eventos 2023](https://github.com/agenda-tech-brasil/agenda-tech-brasil/blob/main/arquivo/2023.md)
 - [Eventos 2024](https://github.com/agenda-tech-brasil/agenda-tech-brasil/blob/main/arquivo/2024.md)
+- [Eventos 2025](https://github.com/agenda-tech-brasil/agenda-tech-brasil/blob/main/arquivo/2025.md)
 
 <!--LINK DAS BADGES:START-->
 

--- a/arquivo/2024.md
+++ b/arquivo/2024.md
@@ -194,7 +194,7 @@
 - 16, 17, 18 e 19: [XXIV Simpósio Brasileiro de Segurança da Informação e de Sistemas Computacionais (SBSEG 2024)](https://sbseg2024.ita.br/) - _São José dos Campos/SP_ ![presencial]
 - 18, 19 e 20: [TDC São Paulo](https://thedevconf.com/tdc/2024/sao-paulo/) - _São Paulo/SP_ ![híbrido]
 - 17 e 19: [Mind The Sec](https://mindthesec.com.br/) - _São Paulo/SP_ ![presencial]
-- 19: [Encontro PyLadies e Grupy SP](https://developer.microsoft.com/en-us/reactor/events/23425/?wt.mc_id=1reg_23425_webpage_reactor)) - _São Paulo/SP_ ![presencial]
+- 19: [Encontro PyLadies e Grupy SP](https://developer.microsoft.com/en-us/reactor/events/23425/?wt.mc_id=1reg_23425_webpage_reactor) - _São Paulo/SP_ ![presencial]
 - 19: [DevPR: Meetup sobre empregabilidade](https://meetup.com/developerparana) - _Maringá/PR_ ![presencial]
 - 20: [Meetup Thasfin #18 | Fcamara](https://guild.host/events/thasfin-18-fcamara-6l5jtr) - _São Paulo/SP_ ![presencial]
 - 20 e 21: [JoinCommunity](https://joincommunity.com.br/) - _Goiânia/GO_ ![presencial]

--- a/src/export_archive.py
+++ b/src/export_archive.py
@@ -3,11 +3,7 @@ import os
 from jinja2 import Environment, FileSystemLoader
 
 from generate_page import format_date_list
-from utils import get_db_path, load_database
-
-
-def get_archived_years(data):
-    return [y for y in data.get("eventos", []) if y.get("arquivado", False)]
+from utils import get_archived_years, get_db_path, load_database
 
 
 def render_archive(year_data, template_path):
@@ -28,9 +24,6 @@ def export_archives(db_path, template_path, output_dir):
     os.makedirs(output_dir, exist_ok=True)
 
     for year_data in archived_years:
-        if not year_data.get("meses"):
-            continue
-
         content = render_archive(year_data, template_path)
         output_path = os.path.join(output_dir, f"{year_data['ano']}.md")
 

--- a/src/generate_page.py
+++ b/src/generate_page.py
@@ -3,7 +3,7 @@ import os
 
 from jinja2 import Environment, FileSystemLoader
 
-from utils import get_db_path, load_database
+from utils import get_archived_years, get_db_path, load_database
 
 
 def format_date_list(dates):
@@ -25,6 +25,7 @@ def get_available_months(json_data, current_year):
 
 def render_markdown(json_data, template_path, current_year):
     available_months = get_available_months(json_data, current_year)
+    archived_years = sorted(year["ano"] for year in get_archived_years(json_data))
 
     env = Environment(
         loader=FileSystemLoader(template_path),
@@ -34,7 +35,11 @@ def render_markdown(json_data, template_path, current_year):
     env.filters["format_date_list"] = format_date_list
     template = env.get_template("events.md.j2")
 
-    return template.render(data=json_data, link_meses=available_months)
+    return template.render(
+        data=json_data,
+        link_meses=available_months,
+        anos_arquivados=archived_years,
+    )
 
 
 def generate_readme(db_path, template_path, output_path, now=None):

--- a/src/templates/events.md.j2
+++ b/src/templates/events.md.j2
@@ -57,9 +57,9 @@ Pode ser que ainda não tenhamos adicionado ao nosso calendário de eventos! Se 
 
 ## Eventos dos anos anteriores
 
-- [Eventos 2022](https://github.com/agenda-tech-brasil/agenda-tech-brasil/blob/main/arquivo/2022.md)
-- [Eventos 2023](https://github.com/agenda-tech-brasil/agenda-tech-brasil/blob/main/arquivo/2023.md)
-- [Eventos 2024](https://github.com/agenda-tech-brasil/agenda-tech-brasil/blob/main/arquivo/2024.md)
+{% for ano_arquivado in anos_arquivados %}
+- [Eventos {{ ano_arquivado }}](https://github.com/agenda-tech-brasil/agenda-tech-brasil/blob/main/arquivo/{{ ano_arquivado }}.md)
+{% endfor %}
 
 <!--LINK DAS BADGES:START-->
 

--- a/src/tests/test_export_archive.py
+++ b/src/tests/test_export_archive.py
@@ -25,9 +25,30 @@ def test_get_archived_years_returns_only_archived():
 
     result = get_archived_years(data)
 
-    assert len(result) == 2
-    assert result[0]["ano"] == 2024
-    assert result[1]["ano"] == 2023
+    assert len(result) == 1
+    assert result[0]["ano"] == 2023
+
+
+def test_get_archived_years_includes_archived_months_of_active_year():
+    data = {
+        "eventos": [
+            {
+                "ano": 2026,
+                "arquivado": False,
+                "meses": [
+                    {"mes": "janeiro", "arquivado": True, "eventos": []},
+                    {"mes": "fevereiro", "arquivado": False, "eventos": []},
+                ],
+            },
+        ],
+        "tba": [],
+    }
+
+    result = get_archived_years(data)
+
+    assert len(result) == 1
+    assert result[0]["ano"] == 2026
+    assert [m["mes"] for m in result[0]["meses"]] == ["janeiro"]
 
 
 def test_get_archived_years_returns_empty_when_none_archived():
@@ -170,6 +191,41 @@ def test_export_archives_creates_year_files(tmp_path):
     assert "### Março" in content
     assert "Conf X" in content
     assert not (output_dir / "2026.md").exists()
+
+
+def test_export_archives_creates_file_for_year_with_archived_month(tmp_path):
+    db_path = tmp_path / "db.json"
+    template_dir = tmp_path / "templates"
+    output_dir = tmp_path / "arquivo"
+    template_dir.mkdir()
+
+    template_content = (
+        "{% for mes in ano.meses %}"
+        "### {{ mes.mes | capitalize }}\n"
+        "{% endfor %}"
+    )
+    (template_dir / "archive.md.j2").write_text(template_content, encoding="utf-8")
+
+    db_data = {
+        "eventos": [
+            {
+                "ano": 2026,
+                "arquivado": False,
+                "meses": [
+                    {"mes": "janeiro", "arquivado": True, "eventos": []},
+                    {"mes": "fevereiro", "arquivado": False, "eventos": []},
+                ],
+            },
+        ],
+        "tba": [],
+    }
+    write_db(db_path, db_data)
+
+    export_archives(str(db_path), str(template_dir), str(output_dir))
+
+    content = (output_dir / "2026.md").read_text(encoding="utf-8")
+    assert "### Janeiro" in content
+    assert "### Fevereiro" not in content
 
 
 def test_export_archives_skips_archived_year_without_meses(tmp_path):

--- a/src/tests/test_generate_page.py
+++ b/src/tests/test_generate_page.py
@@ -150,6 +150,47 @@ def test_generate_readme_renders_two_events(tmp_path):
     assert "20 - Evento B" in output
 
 
+def test_generate_readme_renders_archived_years_links(tmp_path):
+    db_path = tmp_path / "database.json"
+    template_dir = tmp_path / "templates"
+    output_path = tmp_path / "README.md"
+    template_dir.mkdir()
+
+    db_data = {
+        "eventos": [
+            {
+                "ano": 2024,
+                "arquivado": True,
+                "meses": [{"mes": "janeiro", "arquivado": True, "eventos": []}],
+            },
+            {
+                "ano": 2026,
+                "arquivado": False,
+                "meses": [
+                    {"mes": "janeiro", "arquivado": True, "eventos": []},
+                    {"mes": "fevereiro", "arquivado": False, "eventos": []},
+                ],
+            },
+        ],
+        "tba": [],
+    }
+
+    db_path.write_text(json.dumps(db_data, ensure_ascii=False), encoding="utf-8")
+    template = "{% for ano_arquivado in anos_arquivados %}[Eventos {{ ano_arquivado }}] {% endfor %}"
+    (template_dir / "events.md.j2").write_text(template, encoding="utf-8")
+
+    generate_readme(
+        str(db_path),
+        str(template_dir),
+        str(output_path),
+        now=datetime(2026, 1, 1),
+    )
+
+    output = output_path.read_text(encoding="utf-8")
+    assert "[Eventos 2024]" in output
+    assert "[Eventos 2026]" in output
+
+
 def test_main_calls_generate_readme_with_expected_paths():
     with patch("generate_page.generate_readme") as mocked_generate_readme, patch(
         "builtins.print"

--- a/src/utils.py
+++ b/src/utils.py
@@ -62,6 +62,27 @@ def save_database(file_path, data):
         json.dump(data, f, indent=2, ensure_ascii=False)
 
 
+def get_archived_years(data):
+    """
+    Retorna os anos que possuem conteúdo arquivado, contendo apenas os meses arquivados.
+
+    Um ano entra na lista quando está arquivado (todos os meses contam) ou quando
+    possui ao menos um mês marcado como arquivado. Anos sem meses arquivados são
+    ignorados.
+    """
+    archived_years = []
+    for year_data in data.get("eventos", []):
+        year_archived = year_data.get("arquivado", False)
+        archived_months = [
+            month
+            for month in year_data.get("meses", [])
+            if year_archived or month.get("arquivado", False)
+        ]
+        if archived_months:
+            archived_years.append({**year_data, "meses": archived_months})
+    return archived_years
+
+
 def find_year(data, year):
     """Busca e retorna a entrada do ano em data['eventos'], ou None."""
     return next((y for y in data["eventos"] if y["ano"] == year), None)


### PR DESCRIPTION
Closes #940

## Descrição

Automatiza a geração dos markdowns de arquivamento, eliminando a etapa manual descrita na issue. Após a issue de arquivamento marcar o mês/ano no `database.json`, o próprio workflow agora gera os arquivos de markdown e os inclui no PR.

## O que foi feito

- **`src/utils.py`**: nova função `get_archived_years`, que considera arquivado tanto o ano inteiro quanto meses individuais dentro de um ano ainda ativo, retornando cada ano apenas com seus meses arquivados.
- **`src/export_archive.py`**: passa a usar o helper acima — agora o arquivo anual (`arquivo/<ano>.md`) é criado/regenerado mesmo quando apenas alguns meses do ano foram arquivados. A geração é completa a cada execução, garantindo a ordenação e a consistência mesmo em arquivamentos fora de ordem, conforme proposto na issue.
- **`src/templates/events.md.j2` + `src/generate_page.py`**: a seção "Eventos dos anos anteriores" do `README.md` deixa de ser hardcoded e passa a ser gerada dinamicamente a partir do `database.json` (de quebra, corrige o link de **Eventos 2025**, que estava faltando).
- **`.github/workflows/archive-events.yml`**: após `archive.py`, executa `export_archive.py` e `generate_page.py`, adicionando `arquivo/` e `README.md` ao commit do PR de arquivamento. Também corrige a mensagem de commit, que dizia "Adicionando novo evento".
- **Testes**: novos casos cobrindo mês arquivado dentro de ano ativo e os links dinâmicos de anos anteriores (67 testes passando, cobertura 97,9%).

Os arquivos `README.md` e `arquivo/2024.md` deste PR foram regenerados pelos próprios scripts: o README ficou sincronizado com o `database.json` atual e o `2024.md` perdeu um parêntese sobrando em uma URL. Os demais arquivos de `arquivo/` foram regenerados sem nenhuma diferença, confirmando que a regeneração completa é idempotente.

## Como testar

```bash
pip install -r src/requirements.txt
python src/export_archive.py
python src/generate_page.py
pytest src/tests
```