### PR TITLE
fix: reflect issue edits in the generated event PR

### DIFF
--- a/.github/workflows/archive-events.yml
+++ b/.github/workflows/archive-events.yml
@@ -1,7 +1,7 @@
 name: "[CI] Arquivar Agenda(s)/Evento(s)"
 on:
   issues:
-    types: [opened]
+    types: [opened, edited]
 
 permissions:
   contents: write
@@ -67,12 +67,17 @@ jobs:
           git checkout -b $branch_name
           git add src/db/database.json
           git commit -m "Adicionando novo evento: ${{ env.event_name }}"
-          git push origin $branch_name
+          git push --force origin $branch_name
 
           echo "branch_name=${branch_name}" >> $GITHUB_ENV
 
       - name: Criar Pull Request
         run: |
+          if [ -n "$(gh pr list --head "${{ env.branch_name }}" --state open --json number --jq '.[].number')" ]; then
+            echo "PR já existe para ${{ env.branch_name }}; o push --force atualizou o conteúdo."
+            exit 0
+          fi
+
           gh pr create \
           -B main \
           -H ${{ env.branch_name }} \

--- a/.github/workflows/create-event.yml
+++ b/.github/workflows/create-event.yml
@@ -1,7 +1,7 @@
 name: "[CI] Cadastrar Agenda/Evento"
 on:
   issues:
-    types: [opened]
+    types: [opened, edited]
 
 permissions:
   contents: write
@@ -90,12 +90,17 @@ jobs:
           git checkout -b $branch_name
           git add src/db/database.json
           git commit -m "Adicionando novo evento: ${{ env.event_name }}"
-          git push origin $branch_name
+          git push --force origin $branch_name
 
           echo "branch_name=${branch_name}" >> $GITHUB_ENV
 
       - name: Criar Pull Request
         run: |
+          if [ -n "$(gh pr list --head "${{ env.branch_name }}" --state open --json number --jq '.[].number')" ]; then
+            echo "PR já existe para ${{ env.branch_name }}; o push --force atualizou o conteúdo."
+            exit 0
+          fi
+
           gh pr create \
           -B main \
           -H ${{ env.branch_name }} \
@@ -187,12 +192,17 @@ jobs:
           git checkout -b $branch_name
           git add src/db/database.json
           git commit -m "Adicionando novo evento: ${{ env.event_name }}"
-          git push origin $branch_name
+          git push --force origin $branch_name
 
           echo "branch_name=${branch_name}" >> $GITHUB_ENV
 
       - name: Criar Pull Request
         run: |
+          if [ -n "$(gh pr list --head "${{ env.branch_name }}" --state open --json number --jq '.[].number')" ]; then
+            echo "PR já existe para ${{ env.branch_name }}; o push --force atualizou o conteúdo."
+            exit 0
+          fi
+
           gh pr create \
           -B main \
           -H ${{ env.branch_name }} \
@@ -284,12 +294,17 @@ jobs:
           git checkout -b $branch_name
           git add src/db/database.json
           git commit -m "Adicionando novo evento: ${{ env.event_name }}"
-          git push origin $branch_name
+          git push --force origin $branch_name
 
           echo "branch_name=${branch_name}" >> $GITHUB_ENV
 
       - name: Criar Pull Request
         run: |
+          if [ -n "$(gh pr list --head "${{ env.branch_name }}" --state open --json number --jq '.[].number')" ]; then
+            echo "PR já existe para ${{ env.branch_name }}; o push --force atualizou o conteúdo."
+            exit 0
+          fi
+
           gh pr create \
           -B main \
           -H ${{ env.branch_name }} \

--- a/.github/workflows/delete-event.yml
+++ b/.github/workflows/delete-event.yml
@@ -1,7 +1,7 @@
 name: "[CI] Cancelar Evento/Agenda"
 on:
   issues:
-    types: [opened]
+    types: [opened, edited]
 
 permissions:
   contents: write
@@ -90,12 +90,17 @@ jobs:
           git checkout -b $branch_name
           git add src/db/database.json
           git commit -m "Cancelando evento: ${{ env.event_name }}"
-          git push origin $branch_name
+          git push --force origin $branch_name
 
           echo "branch_name=${branch_name}" >> $GITHUB_ENV
 
       - name: Criar Pull Request
         run: |
+          if [ -n "$(gh pr list --head "${{ env.branch_name }}" --state open --json number --jq '.[].number')" ]; then
+            echo "PR já existe para ${{ env.branch_name }}; o push --force atualizou o conteúdo."
+            exit 0
+          fi
+
           gh pr create \
           -B main \
           -H ${{ env.branch_name }} \


### PR DESCRIPTION
## Tipo de mudança
- [x] `fix` — correção de bug

## Resumo
As workflows de issue→PR disparavam apenas em `opened`, então editar uma issue de template nunca atualizava o PR já aberto (#592). A correção, por job:

- adiciona o gatilho `edited` (`on.issues.types: [opened, edited]`);
- troca `git push` por `git push --force` na branch `feature/add-event-issue-N` (no-op na primeira execução, atualização na edição — o GitHub reflete o novo diff no PR aberto automaticamente);
- protege o `gh pr create` para só rodar quando ainda não há PR aberto para a branch, evitando o erro "a pull request already exists".

Raiz: `create-event.yml`, `delete-event.yml`, `archive-events.yml` (linha `types: [opened]`). Abordagem sancionada na própria issue por @stephan-lopes ("executar novamente a action forçando a nova informação na issue").

Como cada job faz checkout da `main` limpa antes de gerar o evento, reexecutar na edição reconstrói o evento atualizado sem duplicar nada no `database.json`.

## Issue relacionada
Closes #592

## Checklist
- [x] Testes passando (`pytest` — 98% de cobertura; suíte Python intocada)
- [x] Cobertura de testes ≥ 85%
- [x] `src/db/database.json` consistente com o README (sem alterações)
- [x] README renderiza corretamente no GitHub (sem alterações)

---

### Validação
- `actionlint` nas três workflows: **0 novos findings** em relação à `main` (os avisos de shellcheck/SC2086 são preexistentes nas linhas já existentes).
- `python3 -m pytest`: suíte verde, cobertura 97.87% (nenhum arquivo Python foi alterado).

### Observações para revisão
- Mudança puramente YAML/bash: **não há teste automatizado** para gatilhos de Actions. O comportamento na edição precisa ser confirmado em uma issue real reaberta/editada.
- Possível overlap trivial de merge com a PR #1529, que também toca `create-event.yml`.
- O `git push --force` é seguro porque cada execução reconstrói a branch a partir de um único commit sobre a `main` limpa; ele sobrescreve intencionalmente commits manuais nessa branch auto-gerada.
