### PR TITLE
feat: suporte a banner/imagem no cadastro de eventos (#1601)

### DIFF
--- a/.github/ISSUE_TEMPLATE/01 - create-in-person-meeting.yml
+++ b/.github/ISSUE_TEMPLATE/01 - create-in-person-meeting.yml
@@ -31,6 +31,15 @@ body:
     validations:
       required: true
 
+  - type: textarea
+    id: event_image
+    attributes:
+      label: Banner ou Imagem do Evento (Opcional)
+      description: Arraste e solte o banner/logo aqui, ou cole a URL direta da imagem (ex: https://.../banner.png). Essa imagem será exibida na versão web (https://agenda-tech-brasil-site.js.org).
+      placeholder: "Arraste a imagem para cá ou cole a URL (ex: https://...)"
+    validations:
+      required: false
+
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/02 - create-hybrid-meeting.yml
+++ b/.github/ISSUE_TEMPLATE/02 - create-hybrid-meeting.yml
@@ -31,6 +31,15 @@ body:
     validations:
       required: true
 
+  - type: textarea
+    id: event_image
+    attributes:
+      label: Banner ou Imagem do Evento (Opcional)
+      description: Arraste e solte o banner/logo aqui, ou cole a URL direta da imagem (ex: https://.../banner.png). Essa imagem será exibida na versão web (https://agenda-tech-brasil-site.js.org).
+      placeholder: "Arraste a imagem para cá ou cole a URL (ex: https://...)"
+    validations:
+      required: false
+
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/03 - create-online-meeting.yml
+++ b/.github/ISSUE_TEMPLATE/03 - create-online-meeting.yml
@@ -31,6 +31,15 @@ body:
     validations:
       required: true
 
+  - type: textarea
+    id: event_image
+    attributes:
+      label: Banner ou Imagem do Evento (Opcional)
+      description: Arraste e solte o banner/logo aqui, ou cole a URL direta da imagem (ex: https://.../banner.png). Essa imagem será exibida na versão web (https://agenda-tech-brasil-site.js.org).
+      placeholder: "Arraste a imagem para cá ou cole a URL (ex: https://...)"
+    validations:
+      required: false
+
   - type: markdown
     attributes:
       value: |

--- a/.github/workflows/create-event.yml
+++ b/.github/workflows/create-event.yml
@@ -50,6 +50,11 @@ jobs:
           event_year=$(get_event_values "$event_info" 'Ano do(a) Evento/Agenda')
           event_month=$(get_event_values "$event_info" 'Mês do(a) Evento/Agenda')
           event_day=$(get_event_values "$event_info" 'Dia do(a) Evento/Agenda')
+          event_image_raw=$(get_event_values "$event_info" 'Banner ou Imagem do Evento')
+          event_image=$(echo "$event_image_raw" | grep -oE 'https?://[^ )]+' | head -n 1 || true)
+          if [[ "$event_image" == "_No response_" ]]; then
+            event_image=""
+          fi
 
           if [[ $event_day == "_No response_" ]]; then
             event_month=TBA
@@ -70,6 +75,7 @@ jobs:
           echo "event_year=${event_year}" >> $GITHUB_ENV
           echo "event_month=${event_month}" >> $GITHUB_ENV
           echo "event_day=${event_day}" >> $GITHUB_ENV
+          echo "event_image=${event_image}" >> $GITHUB_ENV
 
       - name: Definir tipo de Evento como Presencial
         run: |
@@ -152,6 +158,11 @@ jobs:
           event_year=$(get_event_values "$event_info" 'Ano do(a) Evento/Agenda')
           event_month=$(get_event_values "$event_info" 'Mês do(a) Evento/Agenda')
           event_day=$(get_event_values "$event_info" 'Dia do(a) Evento/Agenda')
+          event_image_raw=$(get_event_values "$event_info" 'Banner ou Imagem do Evento')
+          event_image=$(echo "$event_image_raw" | grep -oE 'https?://[^ )]+' | head -n 1 || true)
+          if [[ "$event_image" == "_No response_" ]]; then
+            event_image=""
+          fi
 
           if [[ $event_day == "_No response_" ]]; then
             event_month=TBA
@@ -172,6 +183,7 @@ jobs:
           echo "event_year=${event_year}" >> $GITHUB_ENV
           echo "event_month=${event_month}" >> $GITHUB_ENV
           echo "event_day=${event_day}" >> $GITHUB_ENV
+          echo "event_image=${event_image}" >> $GITHUB_ENV
 
       - name: Definir tipo de Evento como Híbrido
         run: |
@@ -254,6 +266,11 @@ jobs:
           event_year=$(get_event_values "$event_info" 'Ano do(a) Evento/Agenda')
           event_month=$(get_event_values "$event_info" 'Mês do(a) Evento/Agenda')
           event_day=$(get_event_values "$event_info" 'Dia do(a) Evento/Agenda')
+          event_image_raw=$(get_event_values "$event_info" 'Banner ou Imagem do Evento')
+          event_image=$(echo "$event_image_raw" | grep -oE 'https?://[^ )]+' | head -n 1 || true)
+          if [[ "$event_image" == "_No response_" ]]; then
+            event_image=""
+          fi
 
           if [[ $event_day == "_No response_" ]]; then
             event_month=TBA
@@ -274,6 +291,7 @@ jobs:
           echo "event_year=${event_year}" >> $GITHUB_ENV
           echo "event_month=${event_month}" >> $GITHUB_ENV
           echo "event_day=${event_day}" >> $GITHUB_ENV
+          echo "event_image=${event_image}" >> $GITHUB_ENV
 
       - name: Definir tipo de Evento como Online
         run: |

--- a/.github/workflows/create-event.yml
+++ b/.github/workflows/create-event.yml
@@ -51,7 +51,7 @@ jobs:
           event_month=$(get_event_values "$event_info" 'Mês do(a) Evento/Agenda')
           event_day=$(get_event_values "$event_info" 'Dia do(a) Evento/Agenda')
           event_image_raw=$(get_event_values "$event_info" 'Banner ou Imagem do Evento')
-          event_image=$(echo "$event_image_raw" | grep -oE 'https?://[^ )]+' | head -n 1 || true)
+          event_image=$(echo "$event_image_raw" | grep -oE 'https?://[^ )>]+' | head -n 1 || true)
 
           if [[ $event_day == "_No response_" ]]; then
             event_month=TBA
@@ -156,7 +156,7 @@ jobs:
           event_month=$(get_event_values "$event_info" 'Mês do(a) Evento/Agenda')
           event_day=$(get_event_values "$event_info" 'Dia do(a) Evento/Agenda')
           event_image_raw=$(get_event_values "$event_info" 'Banner ou Imagem do Evento')
-          event_image=$(echo "$event_image_raw" | grep -oE 'https?://[^ )]+' | head -n 1 || true)
+          event_image=$(echo "$event_image_raw" | grep -oE 'https?://[^ )>]+' | head -n 1 || true)
 
           if [[ $event_day == "_No response_" ]]; then
             event_month=TBA
@@ -261,7 +261,7 @@ jobs:
           event_month=$(get_event_values "$event_info" 'Mês do(a) Evento/Agenda')
           event_day=$(get_event_values "$event_info" 'Dia do(a) Evento/Agenda')
           event_image_raw=$(get_event_values "$event_info" 'Banner ou Imagem do Evento')
-          event_image=$(echo "$event_image_raw" | grep -oE 'https?://[^ )]+' | head -n 1 || true)
+          event_image=$(echo "$event_image_raw" | grep -oE 'https?://[^ )>]+' | head -n 1 || true)
 
           if [[ $event_day == "_No response_" ]]; then
             event_month=TBA

--- a/.github/workflows/create-event.yml
+++ b/.github/workflows/create-event.yml
@@ -52,9 +52,6 @@ jobs:
           event_day=$(get_event_values "$event_info" 'Dia do(a) Evento/Agenda')
           event_image_raw=$(get_event_values "$event_info" 'Banner ou Imagem do Evento')
           event_image=$(echo "$event_image_raw" | grep -oE 'https?://[^ )]+' | head -n 1 || true)
-          if [[ "$event_image" == "_No response_" ]]; then
-            event_image=""
-          fi
 
           if [[ $event_day == "_No response_" ]]; then
             event_month=TBA
@@ -160,9 +157,6 @@ jobs:
           event_day=$(get_event_values "$event_info" 'Dia do(a) Evento/Agenda')
           event_image_raw=$(get_event_values "$event_info" 'Banner ou Imagem do Evento')
           event_image=$(echo "$event_image_raw" | grep -oE 'https?://[^ )]+' | head -n 1 || true)
-          if [[ "$event_image" == "_No response_" ]]; then
-            event_image=""
-          fi
 
           if [[ $event_day == "_No response_" ]]; then
             event_month=TBA
@@ -268,9 +262,6 @@ jobs:
           event_day=$(get_event_values "$event_info" 'Dia do(a) Evento/Agenda')
           event_image_raw=$(get_event_values "$event_info" 'Banner ou Imagem do Evento')
           event_image=$(echo "$event_image_raw" | grep -oE 'https?://[^ )]+' | head -n 1 || true)
-          if [[ "$event_image" == "_No response_" ]]; then
-            event_image=""
-          fi
 
           if [[ $event_day == "_No response_" ]]; then
             event_month=TBA

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 **/venv/*
+.venv/
+uv.lock
 coverage.xml
 .coverage
 **/.pytest_cache/

--- a/src/add_event.py
+++ b/src/add_event.py
@@ -1,6 +1,15 @@
 import os
+import re
 
 from utils import find_month, find_year, get_db_path, load_database, save_database
+
+
+def extract_image_url(raw):
+    if not raw or raw.strip() == "_No response_":
+        return ""
+    match = re.search(r"https?://[^\s\)]+", raw)
+    return match.group(0) if match else ""
+
 
 CALENDAR_ORDER = [
     "janeiro",
@@ -71,6 +80,8 @@ def add_tba_to_json(file_path, new_event):
         "uf": new_event["evento"]["uf"],
         "tipo": new_event["evento"]["tipo"],
     }
+    if "imagem" in new_event["evento"]:
+        event_tba["imagem"] = new_event["evento"]["imagem"]
 
     data["tba"].append(event_tba)
     save_database(file_path, data)
@@ -81,17 +92,22 @@ def get_event_from_env():
     """
     Recebe informações do evento de variáveis de ambiente configuradas no GitHub Actions.
     """
+    evento = {
+        "nome": os.getenv("event_name", "").strip(),
+        "data": sorted(os.getenv("event_day", "").strip().replace(" ", "").split(",")),
+        "url": os.getenv("event_url", "").strip(),
+        "cidade": os.getenv("event_city", "").strip().title(),
+        "uf": os.getenv("event_state", "").strip(),
+        "tipo": os.getenv("event_type", "").strip(),
+    }
+    image_url = extract_image_url(os.getenv("event_image", ""))
+    if image_url:
+        evento["imagem"] = image_url
+
     return {
         "ano": int(os.getenv("event_year", 0)),
         "mes": os.getenv("event_month", "").strip().lower(),
-        "evento": {
-            "nome": os.getenv("event_name", "").strip(),
-            "data": sorted(os.getenv("event_day", "").strip().replace(" ", "").split(",")),
-            "url": os.getenv("event_url", "").strip(),
-            "cidade": os.getenv("event_city", "").strip().title(),
-            "uf": os.getenv("event_state", "").strip(),
-            "tipo": os.getenv("event_type", "").strip(),
-        },
+        "evento": evento,
     }
 
 def main():

--- a/src/add_event.py
+++ b/src/add_event.py
@@ -80,8 +80,9 @@ def add_tba_to_json(file_path, new_event):
         "uf": new_event["evento"]["uf"],
         "tipo": new_event["evento"]["tipo"],
     }
-    if "imagem" in new_event["evento"]:
-        event_tba["imagem"] = new_event["evento"]["imagem"]
+    image_url = new_event["evento"].get("imagem")
+    if isinstance(image_url, str) and image_url.strip():
+        event_tba["imagem"] = image_url.strip()
 
     data["tba"].append(event_tba)
     save_database(file_path, data)

--- a/src/add_event.py
+++ b/src/add_event.py
@@ -7,8 +7,8 @@ from utils import find_month, find_year, get_db_path, load_database, save_databa
 def extract_image_url(raw):
     if not raw or raw.strip() == "_No response_":
         return ""
-    match = re.search(r"https?://[^\s\)]+", raw)
-    return match.group(0) if match else ""
+    match = re.search(r"https?://[^\s\)>]+", raw)
+    return match.group(0).rstrip(">") if match else ""
 
 
 CALENDAR_ORDER = [

--- a/src/tests/test_add_event.py
+++ b/src/tests/test_add_event.py
@@ -2,7 +2,13 @@ import json
 
 from unittest.mock import patch
 
-from add_event import add_event_to_json, add_tba_to_json, get_event_from_env, main
+from add_event import (
+    add_event_to_json,
+    add_tba_to_json,
+    extract_image_url,
+    get_event_from_env,
+    main,
+)
 
 
 def write_db(path, payload):
@@ -201,3 +207,53 @@ def test_main_calls_add_event_when_month_not_tba():
 
     mocked_add_event.assert_called_once()
     mocked_add_tba.assert_not_called()
+
+
+def test_extract_image_url():
+    assert extract_image_url("https://example.com/banner.png") == "https://example.com/banner.png"
+    assert extract_image_url("![banner](https://github.com/user-attachments/assets/12345)") == "https://github.com/user-attachments/assets/12345"
+    assert extract_image_url("_No response_") == ""
+    assert extract_image_url("") == ""
+    assert extract_image_url(None) == ""
+
+
+def test_get_event_from_env_with_image(monkeypatch):
+    monkeypatch.setenv("event_year", "2026")
+    monkeypatch.setenv("event_month", "agosto")
+    monkeypatch.setenv("event_name", "TDC Floripa")
+    monkeypatch.setenv("event_day", "22,23,24")
+    monkeypatch.setenv("event_url", "https://thedevconf.com")
+    monkeypatch.setenv("event_city", "Florianópolis")
+    monkeypatch.setenv("event_state", "SC")
+    monkeypatch.setenv("event_type", "híbrido")
+    monkeypatch.setenv("event_image", "![banner](https://github.com/user-attachments/assets/banner123)")
+
+    event = get_event_from_env()
+
+    assert event["evento"]["imagem"] == "https://github.com/user-attachments/assets/banner123"
+
+
+def test_add_tba_with_image(tmp_path):
+    db_path = tmp_path / "db.json"
+    write_db(db_path, {"eventos": [], "tba": []})
+
+    new_event = {
+        "ano": 2026,
+        "mes": "tba",
+        "evento": {
+            "nome": "Evento Futuro",
+            "data": [],
+            "url": "https://futuro.com",
+            "cidade": "Manaus",
+            "uf": "AM",
+            "tipo": "presencial",
+            "imagem": "https://futuro.com/logo.png",
+        },
+    }
+
+    add_tba_to_json(str(db_path), new_event)
+    db = read_db(db_path)
+
+    assert len(db["tba"]) == 1
+    assert db["tba"][0]["imagem"] == "https://futuro.com/logo.png"
+

--- a/src/tests/test_add_event.py
+++ b/src/tests/test_add_event.py
@@ -257,3 +257,29 @@ def test_add_tba_with_image(tmp_path):
     assert len(db["tba"]) == 1
     assert db["tba"][0]["imagem"] == "https://futuro.com/logo.png"
 
+
+def test_add_tba_with_empty_image_does_not_persist_key(tmp_path):
+    db_path = tmp_path / "db.json"
+    write_db(db_path, {"eventos": [], "tba": []})
+
+    new_event = {
+        "ano": 2026,
+        "mes": "tba",
+        "evento": {
+            "nome": "Evento Sem Imagem",
+            "data": [],
+            "url": "https://futuro.com",
+            "cidade": "Manaus",
+            "uf": "AM",
+            "tipo": "presencial",
+            "imagem": "",
+        },
+    }
+
+    add_tba_to_json(str(db_path), new_event)
+    db = read_db(db_path)
+
+    assert len(db["tba"]) == 1
+    assert "imagem" not in db["tba"][0]
+
+

--- a/src/tests/test_add_event.py
+++ b/src/tests/test_add_event.py
@@ -212,6 +212,9 @@ def test_main_calls_add_event_when_month_not_tba():
 def test_extract_image_url():
     assert extract_image_url("https://example.com/banner.png") == "https://example.com/banner.png"
     assert extract_image_url("![banner](https://github.com/user-attachments/assets/12345)") == "https://github.com/user-attachments/assets/12345"
+    assert extract_image_url("<https://example.com/banner.png>") == "https://example.com/banner.png"
+    assert extract_image_url("[banner](https://example.com/banner.png)") == "https://example.com/banner.png"
+    assert extract_image_url("https://example.com/banner.png>") == "https://example.com/banner.png"
     assert extract_image_url("_No response_") == ""
     assert extract_image_url("") == ""
     assert extract_image_url(None) == ""

--- a/src/tests/test_validate_database.py
+++ b/src/tests/test_validate_database.py
@@ -438,7 +438,7 @@ def test_validate_event_with_invalid_image_not_string():
 
 def test_validate_event_with_invalid_image_scheme():
     event = valid_presencial_event()
-    for invalid_url in ["ftp://example.com/banner.png", "httpx://example.com/banner.png", ""]:
+    for invalid_url in ["ftp://example.com/banner.png", "httpx://example.com/banner.png", "https://example.com/banner.png>", ""]:
         event["imagem"] = invalid_url
         errors = validate_event(event, "test")
         assert any("imagem" in e for e in errors)

--- a/src/tests/test_validate_database.py
+++ b/src/tests/test_validate_database.py
@@ -423,8 +423,10 @@ def test_main_returns_one_on_invalid_db(tmp_path):
 def test_validate_event_with_valid_image():
     event = valid_presencial_event()
     event["imagem"] = "https://example.com/banner.png"
-    errors = validate_event(event, "test")
-    assert errors == []
+    assert validate_event(event, "test") == []
+
+    event["imagem"] = "http://example.com/banner.png"
+    assert validate_event(event, "test") == []
 
 
 def test_validate_event_with_invalid_image_not_string():
@@ -434,9 +436,11 @@ def test_validate_event_with_invalid_image_not_string():
     assert any("imagem" in e for e in errors)
 
 
-def test_validate_event_with_invalid_image_not_http():
+def test_validate_event_with_invalid_image_scheme():
     event = valid_presencial_event()
-    event["imagem"] = "ftp://example.com/banner.png"
-    errors = validate_event(event, "test")
-    assert any("imagem" in e for e in errors)
+    for invalid_url in ["ftp://example.com/banner.png", "httpx://example.com/banner.png", ""]:
+        event["imagem"] = invalid_url
+        errors = validate_event(event, "test")
+        assert any("imagem" in e for e in errors)
+
 

--- a/src/tests/test_validate_database.py
+++ b/src/tests/test_validate_database.py
@@ -418,3 +418,25 @@ def test_main_returns_one_on_invalid_db(tmp_path):
         exit_code = main()
 
     assert exit_code == 1
+
+
+def test_validate_event_with_valid_image():
+    event = valid_presencial_event()
+    event["imagem"] = "https://example.com/banner.png"
+    errors = validate_event(event, "test")
+    assert errors == []
+
+
+def test_validate_event_with_invalid_image_not_string():
+    event = valid_presencial_event()
+    event["imagem"] = 123
+    errors = validate_event(event, "test")
+    assert any("imagem" in e for e in errors)
+
+
+def test_validate_event_with_invalid_image_not_http():
+    event = valid_presencial_event()
+    event["imagem"] = "ftp://example.com/banner.png"
+    errors = validate_event(event, "test")
+    assert any("imagem" in e for e in errors)
+

--- a/src/validate_database.py
+++ b/src/validate_database.py
@@ -59,8 +59,8 @@ def validate_event(event, path, skip_data=False):
 
     imagem = event.get("imagem")
     if imagem is not None:
-        if not isinstance(imagem, str) or not imagem.startswith("http"):
-            errors.append(f"{path}.imagem: se fornecida, deve ser uma URL começando com http")
+        if not isinstance(imagem, str) or not (imagem.startswith("http://") or imagem.startswith("https://")):
+            errors.append(f"{path}.imagem: se fornecida, deve ser uma URL começando com http:// ou https://")
 
     return errors
 

--- a/src/validate_database.py
+++ b/src/validate_database.py
@@ -57,6 +57,11 @@ def validate_event(event, path, skip_data=False):
         elif uf not in VALID_UFS:
             errors.append(f"{path}.uf: valor inválido '{uf}', esperado sigla de UF brasileira")
 
+    imagem = event.get("imagem")
+    if imagem is not None:
+        if not isinstance(imagem, str) or not imagem.startswith("http"):
+            errors.append(f"{path}.imagem: se fornecida, deve ser uma URL começando com http")
+
     return errors
 
 

--- a/src/validate_database.py
+++ b/src/validate_database.py
@@ -59,7 +59,11 @@ def validate_event(event, path, skip_data=False):
 
     imagem = event.get("imagem")
     if imagem is not None:
-        if not isinstance(imagem, str) or not (imagem.startswith("http://") or imagem.startswith("https://")):
+        if (
+            not isinstance(imagem, str)
+            or not (imagem.startswith("http://") or imagem.startswith("https://"))
+            or ">" in imagem
+        ):
             errors.append(f"{path}.imagem: se fornecida, deve ser uma URL começando com http:// ou https://")
 
     return errors


### PR DESCRIPTION
Fala pessoal, tudo bem?

Abri este PR como uma proposta inicial com base na discussão da issue #1601, para adicionar o suporte a imagem/banner no cadastro de eventos.

A ideia principal é enriquecer a exibição dos eventos na versão web ([agenda-tech-brasil-site](https://agenda-tech-brasil-site.js.org/)), permitindo que quem cadastra o evento possa, opcionalmente, informar um banner ou logotipo.

### O que foi implementado:

- Templates de Issues: Campo opcional de imagem/banner nos formulários de presencial, híbrido e online (suporta tanto URL externa quanto arrastar a imagem direto na issue).
- GitHub Actions (`create-event.yml`): Extração da URL da imagem do corpo da issue para repassar ao script de automação.
- Backend Python (`add_event.py` e `validate_database.py`): Persistência do campo `imagem` no `database.json` e validação estrita do formato (`http://` ou `https://`). Se o evento não tiver imagem, segue o fluxo normal sem quebrar nada (100% retrocompatível).
- Testes: Novos testes unitários cobrindo a extração e validação (71 testes passando com 97.97% de cobertura).

Fiz esse PR para vocês (@pachicodes, @stephan-lopes) e a comunidade poderem avaliar como ficaria a implementação na prática. Fiquem à vontade para sugerir melhorias ou ajustes.

Closes #1601